### PR TITLE
Passwords should be invisible to the accessibility services

### DIFF
--- a/authorizer/src/main/res/layout/activity_otp_add.xml
+++ b/authorizer/src/main/res/layout/activity_otp_add.xml
@@ -65,6 +65,7 @@
                         android:digits="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ234567="
                         android:hint="@string/base32"
                         android:inputType="textVisiblePassword|textCapCharacters|textNoSuggestions"
+                        android:importantForAccessibility="no"
                         android:textAppearance="?android:attr/textAppearanceSmall" />
                 </TableRow>
 

--- a/authorizer/src/main/res/layout/fragment_passwdsafe_change_password.xml
+++ b/authorizer/src/main/res/layout/fragment_passwdsafe_change_password.xml
@@ -40,6 +40,7 @@
                 android:gravity="fill_horizontal"
                 android:hint="@string/password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:scrollHorizontally="true"
                 android:singleLine="true"/>
         </android.support.design.widget.TextInputLayout>
@@ -57,6 +58,7 @@
                 android:hint="@string/confirm"
                 android:imeOptions="actionGo"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:scrollHorizontally="true"
                 android:singleLine="true"/>
         </android.support.design.widget.TextInputLayout>

--- a/authorizer/src/main/res/layout/fragment_passwdsafe_edit_record.xml
+++ b/authorizer/src/main/res/layout/fragment_passwdsafe_edit_record.xml
@@ -189,6 +189,7 @@
                           android:layout_marginLeft="6dp"
                           android:layout_marginStart="6dp"
                           android:inputType="textPassword"
+                          android:importantForAccessibility="no"
                           android:textAppearance="?android:attr/textAppearanceMedium"
                           android:typeface="monospace"
                           tools:ignore="TextViewEdits"/>
@@ -210,6 +211,7 @@
                         android:layout_height="wrap_content"
                         android:hint="@string/password"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:singleLine="true"/>
                 </android.support.design.widget.TextInputLayout>
 
@@ -243,6 +245,7 @@
                         android:layout_height="wrap_content"
                         android:hint="@string/confirm"
                         android:inputType="textPassword"
+                        android:importantForAccessibility="no"
                         android:singleLine="true"/>
                 </android.support.design.widget.TextInputLayout>
 

--- a/authorizer/src/main/res/layout/fragment_passwdsafe_new_file.xml
+++ b/authorizer/src/main/res/layout/fragment_passwdsafe_new_file.xml
@@ -57,6 +57,7 @@
                 android:gravity="fill_horizontal"
                 android:hint="@string/password"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:scrollHorizontally="true"
                 android:singleLine="true"/>
         </android.support.design.widget.TextInputLayout>
@@ -74,6 +75,7 @@
                 android:hint="@string/confirm"
                 android:imeOptions="actionGo"
                 android:inputType="textPassword"
+                android:importantForAccessibility="no"
                 android:scrollHorizontally="true"
                 android:singleLine="true"/>
         </android.support.design.widget.TextInputLayout>

--- a/authorizer/src/main/res/layout/fragment_passwdsafe_open_file.xml
+++ b/authorizer/src/main/res/layout/fragment_passwdsafe_open_file.xml
@@ -45,6 +45,7 @@
                     android:hint="@string/password"
                     android:imeOptions="actionGo"
                     android:inputType="textPassword"
+                    android:importantForAccessibility="no"
                     android:scrollHorizontally="true"
                     android:singleLine="true"
                     android:textAppearance="?android:attr/textAppearanceMedium"/>


### PR DESCRIPTION
Due to recent attacks, malicious apps that are using the accessibility service can capture all user inputs. In this case, the passwords should be ignored for the accessibility service, so such attacks cannot happen. This is done by our research project in CISPA, Saarland University, Germany.